### PR TITLE
Removed redundant module launcher command from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,3 @@ RUN mkdir -p /opt/spring/modules
 ADD artifacts/modules /opt/spring/modules
 ADD build/libs/module-launcher-0.0.1-SNAPSHOT.jar module-launcher.jar
 RUN bash -c 'touch /module-launcher.jar'
-ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/module-launcher.jar"]


### PR DESCRIPTION
The Receptor API provides facilities to run a process.  This commit
removes the redundant call in the Dockerfile, making it generic for just
the packaging of modules regardless of their execution mode (task or
LRP).
